### PR TITLE
Fav rollout

### DIFF
--- a/prod/docker-image-version.txt
+++ b/prod/docker-image-version.txt
@@ -1,1 +1,1 @@
-fordmadox/archivesspace:2.4.1.yale.20181220
+fordmadox/archivesspace:2.4.1.yale.20190822

--- a/prod/plugins.yml
+++ b/prod/plugins.yml
@@ -63,6 +63,10 @@ plugins:
     git: true
     branch: "master"
     url: https://github.com/YaleArchivesSpace/yale_pui_customizations.git
+  - name: in_a_rush
+    git: true
+    branch: "master"
+    url: https://github.com/marktriggs/in_a_rush.git
   - name: child_publisher
     git: true
     branch: "0.5"
@@ -75,10 +79,22 @@ plugins:
     git: true
     branch: "master"
     url: https://github.com/YaleArchivesSpace/yale_marcxml_export_plugin.git
+  - name: yale_series_titles
+    git: true
+    branch: "mixed_content"
+    url: https://github.com/YaleArchivesSpace/yale_series_titles.git
+  - name: ancestor_search_error_addon
+    git: true
+    branch: "master"
+    url: https://github.com/YaleArchivesSpace/ancestor_search_error_addon.git
   - name: yale_accession_slips
     git: true
     branch: "master"
     url: https://github.com/hudmol/yale_accession_slips.git
+  - name: display_multiple_containers
+    git: true
+    branch: "master"
+    url: https://github.com/YaleArchivesSpace/display_multiple_containers.git
   - name: YAML
     git: true
     branch: "master"


### PR DESCRIPTION
Promote changes related to FAV from QA/Test to Prod. Includes

 - New docker image version
 - Added "In a Rush" keyboard shortcut plugin
 - "Yale Series Title" series heading display reformatting plugin
 - "Ancestor search error" ad-hoc patch for a bug that is resolved in a newer version of aspace
 - "display multiple containers" improves how container information is presented