### PR TITLE
fix for 2.6 and up

### DIFF
--- a/dev/plugins.yml
+++ b/dev/plugins.yml
@@ -57,7 +57,7 @@ plugins:
     url: https://github.com/hudmol/digitization_work_order.git
   - name: ArchivesSpace-Aeon-Fulfillment-Plugin
     git: true
-    branch: "local-updates"
+    branch: "master"
     url: https://github.com/YaleArchivesSpace/ArchivesSpace-Aeon-Fulfillment-Plugin.git
   - name: yale_aeon_mappings
     git: true


### PR DESCRIPTION
I didn't go through the process of re-localizing the plugin so that it uses our preferred icon, etc., but this should make things work in DEV again.  No more "can't convert String into Integer (TypeError)" messages, at least.