### PR TITLE
updates to test yaml fix

### DIFF
--- a/qa/plugins.yml
+++ b/qa/plugins.yml
@@ -53,7 +53,7 @@ plugins:
     url: https://github.com/YaleArchivesSpace/ArchivesSpace-Aeon-Fulfillment-Plugin.git
   - name: yale_aeon_mappings
     git: true
-    branch: "test"
+    branch: "master"
     url: https://github.com/YaleArchivesSpace/yale_aeon_mappings.git
   - name: child_publisher
     git: true
@@ -61,11 +61,11 @@ plugins:
     url: https://github.com/hudmol/child_publisher.git
   - name: yale_marcxml_export_plugin
     git: true
-    branch: "test"
+    branch: "master"
     url: https://github.com/YaleArchivesSpace/yale_marcxml_export_plugin.git
   - name: yale_series_titles
     git: true
-    branch: "mixed_content"
+    branch: "master"
     url: https://github.com/YaleArchivesSpace/yale_series_titles.git
   - name: yale_accession_slips
     git: true
@@ -73,7 +73,7 @@ plugins:
     url: https://github.com/hudmol/yale_accession_slips.git
   - name: display_multiple_containers
     git: true
-    branch: "test"
+    branch: "master"
     url: https://github.com/YaleArchivesSpace/display_multiple_containers.git
   - name: omniauthCas
     git: true
@@ -81,7 +81,7 @@ plugins:
     url: https://github.com/YaleArchivesSpace/aspace-omniauth-cas.git
   - name: archivesspace_delete_button_context_plugin
     git: true
-    branch: "test"
+    branch: "master"
     url: https://github.com/YaleArchivesSpace/archivesspace_delete_button_context_plugin.git
   - name: yale_onsite_locations
     git: true
@@ -93,11 +93,11 @@ plugins:
     url: https://github.com/hudmol/yale_repositories.git
   - name: yale_pui_customizations
     git: true
-    branch: "test"
+    branch: "master"
     url: https://github.com/YaleArchivesSpace/yale_pui_customizations.git
   - name: yale_staff_customizations
     git: true
-    branch: "test"
+    branch: "master"
     url: https://github.com/YaleArchivesSpace/yale_staff_customizations.git
   - name: yale-archivesspace-reports
     git: true

--- a/test/plugins.yml
+++ b/test/plugins.yml
@@ -105,7 +105,7 @@ plugins:
     url: https://github.com/YaleArchivesSpace/yale_pui_customizations.git
   - name: yale_staff_customizations
     git: true
-    branch: "master"
+    branch: "test"
     url: https://github.com/YaleArchivesSpace/yale_staff_customizations.git
   - name: yale-archivesspace-reports
     git: true


### PR DESCRIPTION
Should test the YAML updates in TEST before pushing to PROD.  

When removing the old YAML plugin, I took out a lot of redundant yml mappings (our original YML overrides were done by replacing the core YML files).  I had assumed that the fund code translations were in the plugin, but only the currency codes are.  I'm adding those translations back (and removing a lot of double quotes) from the new "yale_staff_customizations" plugin, which contains the staff YML overrides.  See:  https://github.com/YaleArchivesSpace/yale_staff_customizations/commits/test

So, we need to restart TEST and re-set that plugin back to the 'test' branch... and if all looks good there, we can merge to 'master', and pull in the updates to PROD.